### PR TITLE
Installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,25 +8,26 @@ For the average consumer, Time Machine is an excellent choice, especially consid
 
 Asimov aims to solve that problem, scanning your filesystem for known dependency directories (e.g. `node_modules/` living adjacent to a `package.json` file) and excluding them from Time Machine backups. After all, why eat up space on your backup drive for something you could easily restore via `npm install`?
 
-## Usage
+## Installation
 
-After cloning the repository or downloading and extracting an archive, run the following to automatically exclude dependencies from Time Machine backups:
+To get started with Asimov, clone the repository or download and extract an archive anywhere you'd like on your Mac (such as `/usr/local`):
 
-```bash
-# Make the script executable (you'll only need to do this once).
-$ chmod +x ./asimov
-
-# Run Asimov.
-$ ./asimov
+```sh
+$ git clone git@github.com:stevegrunwell/asimov.git /usr/local/asimov
 ```
 
-You may wish to schedule Asimov to run automatically, ensuring new projects are automatically excluded from backups. Don't worry about running it multiple times, Asimov is smart enough to see if a directory has already been marked for exclusion.
+After you've cloned the repository, run the `install.sh` script to automatically:
+* Symlink Asimov to `/usr/local/bin`, making it readily available from anywhere.
+* Schedule Asimov to run once a day, ensuring new projects' dependencies are quickly excluded from Time Machine backups.
+* Run Asimov for the first time, finding all current project dependencies adding them to Time Machine's exclusion list.
 
 ## How it works
 
 At its essence, Asimov is a simple wrapper around Apple's `tmutil` program, which provides more granular control over Time Machine.
 
 Asimov finds recognized dependency directories, verifies that the corresponding dependency file exists and, if so, tells Time Machine not to worry about backing up the dependency directory.
+
+Don't worry about running it multiple times, either. Asimov is smart enough to see if a directory has already been marked for exclusion.
 
 ### Retrieving excluded files
 

--- a/com.stevegrunwell.asimov.plist
+++ b/com.stevegrunwell.asimov.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Label</key>
+        <string>com.stevegrunwell.asimov</string>
+        <key>Program</key>
+        <string>/usr/local/bin/asimov</string>
+        <key>StartInterval</key>
+        <!-- 24 hours = 60 * 60 * 24 -->
+        <integer>86400</integer>
+    </dict>
+</plist>

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Install Asimov as a launchd daemon.
+#
+# @author  Steve Grunwell
+# @license MIT
+
+PLIST="com.stevegrunwell.asimov.plist"
+
+# Symlink Asimov into /usr/local/bin.
+echo -e "\\033[0;36mSymlinking ${PWD}/asimov to /usr/local/bin/asimov\\033[0m"
+ln -si "${PWD}/asimov" /usr/local/bin/asimov
+
+# If it's already loaded, unload first.
+if launchctl list | grep -q com.stevegrunwell.asimov; then
+    echo -e "\\n\\033[0;36mUnloading current instance of ${PLIST}\\033[0m";
+    launchctl unload "$PLIST"
+fi
+
+# Load the .plist file.
+launchctl load "$PLIST" && echo -e "\\n\\033[0;32mAsimov daemon has been loaded!\\033[0m";
+
+# Run Asimov for the first time.
+./asimov

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,9 @@
 
 PLIST="com.stevegrunwell.asimov.plist"
 
+# Verify that Asimov is executable.
+chmod +x ./asimov
+
 # Symlink Asimov into /usr/local/bin.
 echo -e "\\033[0;36mSymlinking ${PWD}/asimov to /usr/local/bin/asimov\\033[0m"
 ln -si "${PWD}/asimov" /usr/local/bin/asimov


### PR DESCRIPTION
This PR adds `install.sh`, which does a few things:

* Automatically make `asimov` executable
* Symlink `./asimov` to `/usr/local/bin/asimov` — not ideal, but launchd wants explicit paths
* Register the `com.stevegrunwell.asimov` launchd job, to run Asimov automatically every 24hr