### PR TITLE
Fix install path + instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Asimov aims to solve that problem, scanning your filesystem for known dependency
 
 ## Installation
 
-To get started with Asimov, clone the repository or download and extract an archive anywhere you'd like on your Mac (such as `/usr/local`):
+To get started with Asimov, clone the repository or download and extract an archive anywhere you'd like on your Mac:
 
 ```sh
-$ git clone git@github.com:stevegrunwell/asimov.git /usr/local/asimov
+$ git clone git@github.com:stevegrunwell/asimov.git
 ```
 
 After you've cloned the repository, run the `install.sh` script to automatically:

--- a/install.sh
+++ b/install.sh
@@ -5,23 +5,24 @@
 # @author  Steve Grunwell
 # @license MIT
 
+DIR=$(dirname "$0")
 PLIST="com.stevegrunwell.asimov.plist"
 
 # Verify that Asimov is executable.
 chmod +x ./asimov
 
 # Symlink Asimov into /usr/local/bin.
-echo -e "\\033[0;36mSymlinking ${PWD}/asimov to /usr/local/bin/asimov\\033[0m"
-ln -si "${PWD}/asimov" /usr/local/bin/asimov
+echo -e "\\033[0;36mSymlinking ${DIR} to /usr/local/bin/asimov\\033[0m"
+ln -si "${DIR}/asimov" /usr/local/bin/asimov
 
 # If it's already loaded, unload first.
 if launchctl list | grep -q com.stevegrunwell.asimov; then
     echo -e "\\n\\033[0;36mUnloading current instance of ${PLIST}\\033[0m";
-    launchctl unload "$PLIST"
+    launchctl unload "${DIR}/${PLIST}"
 fi
 
 # Load the .plist file.
-launchctl load "$PLIST" && echo -e "\\n\\033[0;32mAsimov daemon has been loaded!\\033[0m";
+launchctl load "${DIR}/${PLIST}" && echo -e "\\n\\033[0;32mAsimov daemon has been loaded!\\033[0m";
 
 # Run Asimov for the first time.
-./asimov
+"${DIR}/asimov"


### PR DESCRIPTION
Enables `install.sh` to be run from anywhere on the system.