### PR TITLE
[#7]: Fixes the executable path in the installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@
 # @author  Steve Grunwell
 # @license MIT
 
-DIR=$(dirname "$0")
+DIR="$(pwd)"
 PLIST="com.stevegrunwell.asimov.plist"
 
 # Verify that Asimov is executable.


### PR DESCRIPTION
Switch to using `pwd` for absolute paths instead of the relative path
generated by `dirname $0`.

Before:

    lrwxr-xr-x  1 morganestes  admin     8B Nov 13 18:52 asimov@ -> ./asimov

After:

    lrwxr-xr-x  1 morganestes  admin    45B Nov 13 19:58 asimov@ -> /Users/morganestes/Repositories/asimov/asimov