### PR TITLE
More reliably determine the path to the installation script.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@
 # @author  Steve Grunwell
 # @license MIT
 
-DIR=$(dirname "$0")
+DIR="$(cd "$(dirname "$0")" || return; pwd -P)"
 PLIST="com.stevegrunwell.asimov.plist"
 
 # Verify that Asimov is executable.


### PR DESCRIPTION
Rather than relying on `$(dirname "$0")` or `$(pwd)`, which can have issues with relative paths (e.g. "./install.sh") or the user's current working directory, respectively), this approach literally changes into the script directory to get the full directory. Based on https://stackoverflow.com/a/4774063/329911.

Fixes #7 and closes #8. Props @morganestes.