### PR TITLE
Instead of limiting Asimov to ~/Sites, scope it to the user's home directory

### DIFF
--- a/asimov
+++ b/asimov
@@ -67,5 +67,5 @@ for i in "${FILEPATHS[@]}"; do
     printf "\\n\\033[0;36mFinding %s/ directories with corresponding %s files...\\033[0m\\n" \
         "${parts[0]}" "${parts[1]}"
 
-    find ~/Sites -name "${parts[0]}" -type d | dependency_file_exists "${parts[1]}" | exclude_file
+    find ~ -name "${parts[0]}" -type d | dependency_file_exists "${parts[1]}" | exclude_file
 done


### PR DESCRIPTION
While this may not get *every* instance of these dependencies on a system, it should pick up the typical use-cases while avoiding root-level permission requirements.

Fixes #10.