### PR TITLE
Add pattern for target folder with corresponding src folder

### DIFF
--- a/asimov
+++ b/asimov
@@ -17,6 +17,7 @@
 # @license MIT
 
 readonly FILEPATHS=(
+    "target ../src"
     "vendor ../composer.json"
     "node_modules ../package.json"
     ".vagrant ../Vagrantfile"
@@ -40,7 +41,7 @@ dependency_file_exists() {
             continue;
         fi
 
-        if [ -f "${path}/${filename}" ]; then
+        if [ -e "${path}/${filename}" ]; then
             echo "$path"
         fi
   done


### PR DESCRIPTION
By rather matching on the `src` dir instead `pom.xml` file used by maven, this pattern matches many more build systems including multimodule sbt projects.