### PR TITLE
Remove initial `read -r path` in dependency_file_exists() to stop excluding first match

### DIFF
--- a/asimov
+++ b/asimov
@@ -30,8 +30,6 @@ readonly FILEPATHS=(
 dependency_file_exists() {
     filename=$1
 
-    read -r path;
-
     while read -r path; do
 
         # Return early if this is a nested dependency (e.g. node_modules


### PR DESCRIPTION
I was trying to work out why a particular path wasn't picked up and then realised this was excluding the first match. I can't see any reason for this any more so maybe a hangover from initial development...?