### PR TITLE
Switch to using find's -prune switch to exclude match subdirectories for speed, and exclude ~/Library folder from searches

### DIFF
--- a/asimov
+++ b/asimov
@@ -33,13 +33,6 @@ dependency_file_exists() {
     read -r path;
 
     while read -r path; do
-
-        # Return early if this is a nested dependency (e.g. node_modules
-        # inside another node_modules directory.
-        if [[ $(dirname "$path") == *"/$(basename "$path")/"* ]]; then
-            continue;
-        fi
-
         if [ -f "${path}/${filename}" ]; then
             echo "$path"
         fi
@@ -67,5 +60,5 @@ for i in "${FILEPATHS[@]}"; do
     printf "\\n\\033[0;36mFinding %s/ directories with corresponding %s files...\\033[0m\\n" \
         "${parts[0]}" "${parts[1]}"
 
-    find ~ -name "${parts[0]}" -type d | dependency_file_exists "${parts[1]}" | exclude_file
+    find ~ -not \( -path ~/Library -prune \) -name "${parts[0]}" -type d -prune | dependency_file_exists "${parts[1]}" | exclude_file
 done


### PR DESCRIPTION
This is a ~4x speedup for my machine.

I think excluding ~/Library would be safe for pretty much everyone?

(Prompted by a discussion in Issue #6)