### PR TITLE
Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: bash
+
+notifications:
+  email: never
+
+sudo: false
+
+script:
+  - shellcheck asimov *.sh
+
+matrix:
+  fast_finish: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Asimov
 
+[![Build Status](https://travis-ci.com/stevegrunwell/asimov.svg?branch=master)](https://travis-ci.com/stevegrunwell/asimov)
+
 > Those people who think they know everything are a great annoyance to those of us who do.<br>— Issac Asimov
 
 For macOS users, [Time Machine](https://support.apple.com/en-us/HT201250) is a no-frills, set-it-and-forget-it solution for on-site backups. Plug in an external hard drive (or configure a network storage drive), and your Mac's files are backed up.

--- a/asimov
+++ b/asimov
@@ -71,8 +71,8 @@ for i in "${FILEPATHS[@]}"; do
 
     # Set up a variable for lookup in dependency_file_exists, using a hashed name
     # to ensure the variable name is valid
-    safe_filepath_suffix=$(md5 -qs "${parts[0]}")
-    declare "filepath_${safe_filepath_suffix}"="${parts[1]}"
+    safe_filepath="filepath_$(md5 -qs "${parts[0]}")"
+    declare "$safe_filepath"="${parts[1]}"
 
     ((n++))
 done

--- a/asimov
+++ b/asimov
@@ -31,7 +31,7 @@ dependency_file_exists() {
     read -r path;
 
     while read -r path; do
-        safe_filepath_suffix=$(md5 -qs $(basename "$path"))
+        safe_filepath_suffix=$(md5 -qs "$(basename "$path")")
         filename="filepath_${safe_filepath_suffix}"
         if [ -f "${path}/${!filename}" ]; then
             echo "$path"


### PR DESCRIPTION
This PR enables Travis CI to run [ShellCheck](https://www.shellcheck.net/) automatically on each push. Additionally, it fixes the two outstanding ShellCheck issues.