### PR TITLE
Disable Spotlight indexing by creating .metadata_never_index file in excluded path.

### DIFF
--- a/asimov
+++ b/asimov
@@ -46,7 +46,7 @@ dependency_file_exists() {
 exclude_file() {
     while read -r path; do
         # Disable Spotlight indexing
-        if [ $DISABLE_SPOTLIGHT_INDEXING -a ! -f "${path}/.metadata_never_index" ]; then
+        if [ $DISABLE_SPOTLIGHT_INDEXING ] && [ ! -f "${path}/.metadata_never_index" ]; then
             touch "${path}/.metadata_never_index"
             echo "- ${path} has been excluded from Spotlight Index."
         fi

--- a/asimov
+++ b/asimov
@@ -43,6 +43,9 @@ dependency_file_exists() {
 # Exclude the given path from Time Machine backups.
 exclude_file() {
     while read -r path; do
+        # Disable Spotlight indexing
+        touch "${path}/.metadata_never_index"
+
         if tmutil isexcluded "$path" | grep -q '\[Excluded\]'; then
             echo "- ${path} is already excluded, skipping."
             continue

--- a/asimov
+++ b/asimov
@@ -23,6 +23,8 @@ readonly FILEPATHS=(
     "bower_components ../bower.json"
 )
 
+readonly DISABLE_SPOTLIGHT_INDEXING=false
+
 # Given a directory path, determine if the corresponding file (relative
 # to that directory) is available.
 #
@@ -44,7 +46,10 @@ dependency_file_exists() {
 exclude_file() {
     while read -r path; do
         # Disable Spotlight indexing
-        touch "${path}/.metadata_never_index"
+        if [ $DISABLE_SPOTLIGHT_INDEXING -a ! -f "${path}/.metadata_never_index" ]; then
+            touch "${path}/.metadata_never_index"
+            echo "- ${path} has been excluded from Spotlight Index."
+        fi
 
         if tmutil isexcluded "$path" | grep -q '\[Excluded\]'; then
             echo "- ${path} is already excluded, skipping."


### PR DESCRIPTION
This tools functionality can also be used to exclude project dependencies from showing up in the Spotlight Search. I made this an opt-in for now and it can be enabled by setting the variable `DISABLE_SPOTLIGHT_INDEXING` to true.

There is an open issue in the npm repo to add this file by default:
https://github.com/npm/npm/issues/15346