### PR TITLE
Exclude Java Maven Build Folder

### DIFF
--- a/asimov
+++ b/asimov
@@ -21,6 +21,7 @@ readonly FILEPATHS=(
     "node_modules ../package.json"
     ".vagrant ../Vagrantfile"
     "bower_components ../bower.json"
+    "target ../pom.xml"
 )
 
 # Given a directory path, determine if the corresponding file (relative


### PR DESCRIPTION
This will exclude the Java Maven build folder "target".