### PR TITLE
Support Stack (Haskell)

### DIFF
--- a/asimov
+++ b/asimov
@@ -22,6 +22,7 @@ readonly FILEPATHS=(
     ".vagrant ../Vagrantfile"
     "bower_components ../bower.json"
     "target ../pom.xml"
+    ".stack-work ../stack.yaml"
 )
 
 # Given a directory path, determine if the corresponding file (relative


### PR DESCRIPTION
Stack is a build tool for Haskell projects. Projects managed by Stack can be identified by containing file `stack.yaml`

Savings can be pretty big, excluding `.stack-work` directories saved me up to 735M per project.