### PR TITLE
Use full filepath for chmod

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ DIR="$(cd "$(dirname "$0")" || return; pwd -P)"
 PLIST="com.stevegrunwell.asimov.plist"
 
 # Verify that Asimov is executable.
-chmod +x ./asimov
+chmod +x "${DIR}/asimov"
 
 # Symlink Asimov into /usr/local/bin.
 echo -e "\\033[0;36mSymlinking ${DIR} to /usr/local/bin/asimov\\033[0m"


### PR DESCRIPTION
The command `chmod +x` should use a full path to reach the file asimov.

I created an alias to my local installation of `asimov`, in order to call it whenever I want (as it seems the scheduled execution through the `plist` file is not working in my case) :
```sh
alias asimov='sh ~/_MY_LOCAL_PATH/asimov/install.sh'
```

But when I called it I had this error :
```sh
chmod: ./asimov: No such file or directory
```

This tiny PR fixes this 🙂 .