### PR TITLE
Added Homebrew support

### DIFF
--- a/Formula/asimov.rb
+++ b/Formula/asimov.rb
@@ -1,0 +1,52 @@
+class Asimov < Formula
+  desc "Automatically exclude development dependencies from Apple Time Machine backups "
+  homepage "https://github.com/stevegrunwell/asimov"
+  url "https://github.com/stevegrunwell/asimov/archive/v0.2.0.tar.gz"
+  sha256 "2efb456975af066a17f928787062522de06c14eb322b2d133a8bc3a764cc5376"
+  revision 0
+
+  # Setup HEAD support (install with --HEAD)
+  head "https://github.com/stevegrunwell/asimov.git", :branch => "develop"
+
+  # No bottling necessary
+  bottle :unneeded
+
+  # Define the installation steps
+  def install
+    # Install the application
+    bin.install buildpath/"asimov"
+  end
+
+  # Define launch agent plist options (launch automatically, but also allow manual startup)
+  plist_options :startup => true, :manual => "asimov"
+
+  # Define the agent plist contents
+  def plist; <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+        <dict>
+            <key>Label</key>
+            <string>#{plist_name}</string>
+            <key>Program</key>
+            <string>#{opt_bin}/asimov</string>
+            <key>StartInterval</key>
+            <!-- 24 hours = 60 * 60 * 24 -->
+            <integer>86400</integer>
+        </dict>
+    </plist>
+  EOS
+  end
+
+  # Define tests to run
+  test do
+    # Test that the binary exists
+    assert File.file?(bin/"asimov"), "asimov binary not found"
+
+    # Test that the symlink exists
+    assert File.file?("/usr/local/bin/asimov"), "asimov binary symlink not found in /usr/local/bin"
+
+    # Test that the launch agent plist exists
+    assert File.file?(plist_path), "asimov plist not found in "+plist_path
+  end
+end

--- a/README.md
+++ b/README.md
@@ -10,7 +10,23 @@ For the average consumer, Time Machine is an excellent choice, especially consid
 
 Asimov aims to solve that problem, scanning your filesystem for known dependency directories (e.g. `node_modules/` living adjacent to a `package.json` file) and excluding them from Time Machine backups. After all, why eat up space on your backup drive for something you could easily restore via `npm install`?
 
-## Installation
+## Installation (Homebrew)
+
+First make sure you have [Homebrew](https://brew.sh/) installed, then run:
+```sh
+brew install https://raw.githubusercontent.com/stevegrunwell/asimov/develop/Formula/asimov.rb
+```
+
+After the installation has finished, you can enable automatic startup and scheduling:
+```sh
+sudo brew services start asimov
+```
+or run manually:
+```sh
+asimov
+```
+
+## Installation (Manual)
 
 To get started with Asimov, clone the repository or download and extract an archive anywhere you'd like on your Mac:
 


### PR DESCRIPTION
This PR adds initial Homebrew support, which installs the `asimov` binary, as well as configured a launch agent property list, which the user can optionally enable.

If you'd like, I can also attempt to publish the Homebrew Formula to the official Formula repository, although they're somewhat picky on what they'll accept and what they won't, however I personally think it would not only simplify the installation process, but also provide more traction and visibility for Asimov, as it would then show up in search results (`brew search asimov`) for every single Homebrew user.