### PR TITLE
Fix incorrect directory pruning, simplify path handling

### DIFF
--- a/asimov
+++ b/asimov
@@ -50,7 +50,7 @@ dependency_file_exists() {
 exclude_file() {
     local path
     while read -r path; do
-        if tmutil isexcluded "${path}" | grep -q '\[Excluded\]'; then
+        if tmutil isexcluded "${path}" | grep -Fq '[Excluded]'; then
             echo "- ${path} is already excluded, skipping."
             continue
         fi

--- a/asimov
+++ b/asimov
@@ -85,7 +85,6 @@ for i in "${FILEPATHS[@]}"; do
     ((n++))
 done
 
-
-echo -e "\\n\\033[0;36mFinding dependency directories with corresponding definition files...\\033[0m\\n"
+printf '\n\033[0;36mFinding dependency directories with corresponding definition files…\033[0m\n'
 
 find "${find_parameters[@]}" | dependency_file_exists | exclude_file

--- a/asimov
+++ b/asimov
@@ -46,10 +46,11 @@ dependency_file_exists() {
     done
 }
 
-# Exclude the given path from Time Machine backups.
+# Exclude the given paths from Time Machine backups.
+# Reads the newline-separated list of paths from stdin.
 exclude_file() {
     local path
-    while read -r path; do
+    while IFS=$'\n' read -r path; do
         if tmutil isexcluded "${path}" | grep -Fq '[Excluded]'; then
             echo "- ${path} is already excluded, skipping."
             continue

--- a/asimov
+++ b/asimov
@@ -37,10 +37,10 @@ dependency_file_exists() {
     read -r path;
 
     while read -r path; do
-        safe_filepath_suffix=$(md5 -qs "$(basename "$path")")
+        safe_filepath_suffix=$(md5 -qs "$(basename "${path}")")
         filename="filepath_${safe_filepath_suffix}"
         if [ -f "${path}/${!filename}" ]; then
-            echo "$path"
+            echo "${path}"
         fi
     done
 }
@@ -48,15 +48,15 @@ dependency_file_exists() {
 # Exclude the given path from Time Machine backups.
 exclude_file() {
     while read -r path; do
-        if tmutil isexcluded "$path" | grep -q '\[Excluded\]'; then
+        if tmutil isexcluded "${path}" | grep -q '\[Excluded\]'; then
             echo "- ${path} is already excluded, skipping."
             continue
         fi
 
-        tmutil addexclusion "$path"
+        tmutil addexclusion "${path}"
 
-        sizeondisk=$(du -hs "$path" | cut -f1)
-        echo "- ${path} has been excluded from Time Machine backups ($sizeondisk)."
+        sizeondisk=$(du -hs "${path}" | cut -f1)
+        echo "- ${path} has been excluded from Time Machine backups (${sizeondisk})."
     done
 }
 
@@ -67,7 +67,7 @@ find_parameters=(~ -not \( -path ~/Library -prune \))
 # Iterate over dependencies.
 n=0
 for i in "${FILEPATHS[@]}"; do
-    read -ra parts <<< "$i"
+    read -ra parts <<< "${i}"
 
     # Add this folder to the `find` list, allowing a single `find` command to find all
     if [ "$n" -gt "0" ]; then
@@ -78,7 +78,7 @@ for i in "${FILEPATHS[@]}"; do
     # Set up a variable for lookup in dependency_file_exists, using a hashed name
     # to ensure the variable name is valid
     safe_filepath="filepath_$(md5 -qs "${parts[0]}")"
-    declare "$safe_filepath"="${parts[1]}"
+    declare "${safe_filepath}"="${parts[1]}"
 
     ((n++))
 done

--- a/asimov
+++ b/asimov
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -Eeu -o pipefail
 
 # Look through the local filesystem and exclude development dependencies
 # from Apple Time Machine backups.

--- a/asimov
+++ b/asimov
@@ -17,7 +17,22 @@ set -Eeu -o pipefail
 # @author  Steve Grunwell
 # @license MIT
 
-readonly FILEPATHS=(
+readonly ASIMOV_ROOT=~
+
+# Paths to unconditionally skip over. This prevents Asimov from modifying the
+# Time Machine exclusions for these paths (and decendents). It has an important
+# side-effect of speeding up the search.
+readonly ASIMOV_SKIP_PATHS=(
+    ~/Library
+)
+
+# A list of "directory"/"sentinel" pairs.
+# Each directory will be excluded from backup iff the sentinel file exists
+# alongside.
+#
+# For example, 'node_modules package.json' means "exclude node_modules/ from
+# backup if there is a package.json next to it."
+readonly ASIMOV_VENDOR_DIR_SENTINELS=(
     "vendor ../composer.json"
     "node_modules ../package.json"
     ".vagrant ../Vagrantfile"
@@ -64,13 +79,17 @@ exclude_file() {
     done
 }
 
-# Start to construct the `find` parameter arguments, based on a home directory search
-# but excluding ~/Library
-declare -a find_parameters=(~ -not \( -path ~/Library -prune \))
+# Start to construct the `find` parameter arguments, based on an initial directory.
+declare -a find_parameters=("${ASIMOV_ROOT}")
+
+# Iterate over the skip directories to construct the `find` expression.
+for d in "${ASIMOV_SKIP_PATHS[@]}"; do
+    find_parameters+=( -not \( -path "${d}" -prune \) )
+done
 
 # Iterate over dependencies.
 declare n=0
-for i in "${FILEPATHS[@]}"; do
+for i in "${ASIMOV_VENDOR_DIR_SENTINELS[@]}"; do
     read -ra parts <<< "${i}"
 
     # Add this folder to the `find` list, allowing a single `find` command to find all

--- a/asimov
+++ b/asimov
@@ -57,7 +57,7 @@ exclude_file() {
 
         sizeondisk=$(du -hs "$path" | cut -f1)
         echo "- ${path} has been excluded from Time Machine backups ($sizeondisk)."
-  done
+    done
 }
 
 # Start to construct the `find` parameter arguments, based on a home directory search

--- a/asimov
+++ b/asimov
@@ -33,34 +33,16 @@ readonly ASIMOV_SKIP_PATHS=(
 # For example, 'node_modules package.json' means "exclude node_modules/ from
 # backup if there is a package.json next to it."
 readonly ASIMOV_VENDOR_DIR_SENTINELS=(
-    "vendor ../composer.json"
-    "node_modules ../package.json"
-    ".vagrant ../Vagrantfile"
-    "bower_components ../bower.json"
-    "target ../pom.xml"
-    ".stack-work ../stack.yaml"
-    "Carthage ../Cartfile"
-    "Pods ../Podfile"
-    ".build ../Package.swift"
+    '.build Package.swift'
+    '.stack-work stack.yaml'
+    '.vagrant Vagrantfile'
+    'Carthage Cartfile'
+    'Pods Podfile'
+    'bower_components bower.json'
+    'node_modules package.json'
+    'target pom.xml'
+    'vendor composer.json'
 )
-
-# Given a directory path, determine if the corresponding file (relative
-# to that directory) is available.
-#
-# For example, when looking at a /vendor directory, we may choose to
-# ensure a composer.json file is available.
-dependency_file_exists() {
-    local path
-    read -r path;
-
-    while read -r path; do
-        safe_filepath_suffix=$(md5 -qs "$(basename "${path}")")
-        filename="filepath_${safe_filepath_suffix}"
-        if [ -f "${path}/${!filename}" ]; then
-            echo "${path}"
-        fi
-    done
-}
 
 # Exclude the given paths from Time Machine backups.
 # Reads the newline-separated list of paths from stdin.
@@ -79,33 +61,37 @@ exclude_file() {
     done
 }
 
-# Start to construct the `find` parameter arguments, based on an initial directory.
-declare -a find_parameters=("${ASIMOV_ROOT}")
-
 # Iterate over the skip directories to construct the `find` expression.
+declare -a find_parameters_skip=()
 for d in "${ASIMOV_SKIP_PATHS[@]}"; do
-    find_parameters+=( -not \( -path "${d}" -prune \) )
+    find_parameters_skip+=( -not \( -path "${d}" -prune \) )
 done
 
-# Iterate over dependencies.
-declare n=0
+# Iterate over the directory/sentinel pairs to construct the `find` expression.
+declare -a find_parameters_vendor=()
 for i in "${ASIMOV_VENDOR_DIR_SENTINELS[@]}"; do
     read -ra parts <<< "${i}"
 
     # Add this folder to the `find` list, allowing a single `find` command to find all
-    if [ "$n" -gt "0" ]; then
-        find_parameters+=(-o)
-    fi
-    find_parameters+=(-name "${parts[0]}" -type d -prune)
+    _exclude_name="${parts[0]}"
+    _sibling_sentinel_name="${parts[1]}"
 
-    # Set up a variable for lookup in dependency_file_exists, using a hashed name
-    # to ensure the variable name is valid
-    safe_filepath="filepath_$(md5 -qs "${parts[0]}")"
-    declare "${safe_filepath}"="${parts[1]}"
-
-    ((n++))
+    # Given a directory path, determine if the corresponding file (relative
+    # to that directory) is available.
+    #
+    # For example, when looking at a /vendor directory, we may choose to
+    # ensure a composer.json file is available.
+    find_parameters_vendor+=( -or \( \
+        -type d \
+        -name "${_exclude_name}" \
+        -execdir test -e "${_sibling_sentinel_name}" \; \
+        -prune \
+        -print \
+    \) )
 done
 
 printf '\n\033[0;36mFinding dependency directories with corresponding definition files…\033[0m\n'
 
-find "${find_parameters[@]}" | dependency_file_exists | exclude_file
+find "${ASIMOV_ROOT}" \( "${find_parameters_skip[@]}" \) \( -false "${find_parameters_vendor[@]}" \) \
+    | exclude_file \
+    ;

--- a/asimov
+++ b/asimov
@@ -34,6 +34,7 @@ readonly FILEPATHS=(
 # For example, when looking at a /vendor directory, we may choose to
 # ensure a composer.json file is available.
 dependency_file_exists() {
+    local path
     read -r path;
 
     while read -r path; do
@@ -47,6 +48,7 @@ dependency_file_exists() {
 
 # Exclude the given path from Time Machine backups.
 exclude_file() {
+    local path
     while read -r path; do
         if tmutil isexcluded "${path}" | grep -q '\[Excluded\]'; then
             echo "- ${path} is already excluded, skipping."
@@ -62,10 +64,10 @@ exclude_file() {
 
 # Start to construct the `find` parameter arguments, based on a home directory search
 # but excluding ~/Library
-find_parameters=(~ -not \( -path ~/Library -prune \))
+declare -a find_parameters=(~ -not \( -path ~/Library -prune \))
 
 # Iterate over dependencies.
-n=0
+declare n=0
 for i in "${FILEPATHS[@]}"; do
     read -ra parts <<< "${i}"
 


### PR DESCRIPTION
Noticed some paths were not being visited correctly: search was pruned when a directory name matched, but before checking if the sentinel file existed.

This PR simplifies a number of elements of the implementation by running the sentinel file check via find's `-execdir`. The approach removes the need for the dynamic bash variables etc and should also speed up searches.

This includes some minor code cleanups while I was investigating various approaches.