### PR TITLE
exclude git repo's from time machine

### DIFF
--- a/asimov
+++ b/asimov
@@ -24,6 +24,7 @@ readonly FILEPATHS=(
     "target ../pom.xml"
     ".stack-work ../stack.yaml"
     "Carthage ../Cartfile"
+    ".git HEAD"
 )
 
 # Given a directory path, determine if the corresponding file (relative


### PR DESCRIPTION
This tool saved me a lot of time, so thanks a lot for that! 👍

I needed to exclude git repos too as I always backup my work to cloud.
It might not fit everyone but it can easily be commented out.

To quickly check if there is at least a remote, it could look for `refs/remotes/origin/HEAD` (instead of `HEAD`) but this assumes that one of the remotes is called `origin` which might not always be the case. 