### PR TITLE
Exclude Swift build files and Pods folder

### DIFF
--- a/asimov
+++ b/asimov
@@ -24,6 +24,8 @@ readonly FILEPATHS=(
     "target ../pom.xml"
     ".stack-work ../stack.yaml"
     "Carthage ../Cartfile"
+    "Pods ../Podfile"
+    ".build ../Package.swift"
 )
 
 # Given a directory path, determine if the corresponding file (relative


### PR DESCRIPTION
## Added exclusions
- Cocoapods `Pods` folder
- Swift `.build` folder