### PR TITLE
README: clone https, not ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Asimov aims to solve that problem, scanning your filesystem for known dependency
 To get started with Asimov, clone the repository or download and extract an archive anywhere you'd like on your Mac:
 
 ```sh
-$ git clone git@github.com:stevegrunwell/asimov.git
+$ git clone https://github.com/stevegrunwell/asimov.git --depth 1
 ```
 
 After you've cloned the repository, run the `install.sh` script to automatically:


### PR DESCRIPTION
When one has a pubkey set up, ssh clone with the user "git" often effs up. This commit changes to HTTPS clone with a depth argument in case the repo gets large in the future.