### PR TITLE
Skip the user's ~/.Trash directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Rework the `find` command and path variables so that `find` is only run once however many FILEPATHS are set ([#18], @props @rowanbeentje, yet again 😉)
  Fix incorrect directory pruning, simplify path handling ([#36], props @rwe)
 * Recommend cloning via HTTPS rather than SSH for manual installations ([#52], props @Artoria2e5)
+* Don't look for matches in `~/.Trash` ([#55])
 
 
 ## [Version 0.2.0] — 2017-11-25
@@ -72,3 +73,4 @@ Initial public release.
 [#37]: https://github.com/stevegrunwell/asimov/pull/37
 [#43]: https://github.com/stevegrunwell/asimov/pull/43
 [#52]: https://github.com/stevegrunwell/asimov/pull/52
+[#55]: https://github.com/stevegrunwell/asimov/pull/55

--- a/asimov
+++ b/asimov
@@ -23,6 +23,7 @@ readonly ASIMOV_ROOT=~
 # Time Machine exclusions for these paths (and decendents). It has an important
 # side-effect of speeding up the search.
 readonly ASIMOV_SKIP_PATHS=(
+    ~/.Trash
     ~/Library
 )
 

--- a/tests/AsimovTest.php
+++ b/tests/AsimovTest.php
@@ -112,4 +112,28 @@ class AsimovTest extends TestCase
             'Asimov should not have found any new paths on the second run.'
         );
     }
+
+    /**
+     * @test
+     * @ticket https://github.com/stevegrunwell/asimov/issues/47
+     * @runInSeparateProcess
+     */
+    public function it_should_not_check_a_users_trash_directory()
+    {
+        $this->createDirectoryStructure([
+            '.Trash' => [
+                'My-Project' => [
+                    'vendor'        => [],
+                    'composer.json' => 'Configuration for this platform.',
+                ],
+            ],
+        ]);
+
+        putenv('HOME=' . $this->getFilepath('/'));
+
+        $this->assertEmpty(
+            $this->asimov(),
+            'Asimov should not have been checking the ~/.Trash directory.'
+        );
+    }
 }


### PR DESCRIPTION
Ideally, Time Machine will already be ignoring the trash, but we shoudln't need to spend time going through it.

Fixes #47, refs #19.