### PR TITLE
Exclude Gradle project with a Kotlin build script

### DIFF
--- a/asimov
+++ b/asimov
@@ -45,6 +45,7 @@ readonly ASIMOV_VENDOR_DIR_SENTINELS=(
     'target Cargo.toml'           # Cargo (Rust)
     'target pom.xml'              # Maven
     'build build.gradle'          # Gradle
+    'build build.gradle.kts'      # Gradle kotlin
     'vendor composer.json'        # Composer (PHP)
     'vendor Gemfile'              # Bundler (Ruby)
 )


### PR DESCRIPTION
Gradle build scripts can be written in Kotlin, in which case the build script is called build.gradle.kts. These should also be excluded.