### PR TITLE
Add pyproject.toml as an alternate sentinel for python virtual environments

### DIFF
--- a/asimov
+++ b/asimov
@@ -43,6 +43,7 @@ readonly ASIMOV_VENDOR_DIR_SENTINELS=(
     '.tox tox.ini'                # Tox (Python)
     '.vagrant Vagrantfile'        # Vagrant
     '.venv requirements.txt'      # virtualenv (Python)
+    '.venv pyproject.toml'        # virtualenv (Python)
     'Carthage Cartfile'           # Carthage
     'Pods Podfile'                # CocoaPods
     'bower_components bower.json' # Bower (JavaScript)


### PR DESCRIPTION
Some python projects now don't have a `requirements.txt` and instead have a [pyproject.toml](https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/) file. 

Add `pyproject.toml` as an alternate sentinel file.