### PR TITLE
Exclude Parcel v2 build cache

### DIFF
--- a/asimov
+++ b/asimov
@@ -56,6 +56,7 @@ readonly ASIMOV_VENDOR_DIR_SENTINELS=(
     'build setup.py'                   # Python
     'dist setup.py'                    # PyPI Publishing (Python)
     'node_modules package.json'        # npm, Yarn (NodeJS)
+    '.parcel-cache package.json'       # Parcel v2 cache (JavaScript)
     'target Cargo.toml'                # Cargo (Rust)
     'target pom.xml'                   # Maven
     'target build.sbt'                 # Sbt (Scala)


### PR DESCRIPTION
The Parcel JavaScript bundler uses a cache folder to speed up builds. This cache can grow to a size of several gigabytes. Since Parcel can rebuild the cache from the source files, there is no need to backup these often changing files.