### PR TITLE
Add AWS CDK output directory sentinel

### DIFF
--- a/asimov
+++ b/asimov
@@ -68,6 +68,7 @@ readonly ASIMOV_VENDOR_DIR_SENTINELS=(
     '.build mix.exs'                   # Mix build files (Elixir)
     '.terraform.d .terraformrc'        # Terraform plugin cache
     '.terragrunt-cache terragrunt.hcl' # Terragrunt
+    'cdk.out cdk.json'                 # AWS CDK
 )
 
 # Exclude the given paths from Time Machine backups.


### PR DESCRIPTION
This adds the folder `cdk.out` which is the default directory that synthesized templates are written to by the AWS CDK. These are ignored by default in repositories using the CDK and should be safe to ignore for backups.